### PR TITLE
Build order overlay from age4builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ API calls are done through [AoE4World.com](https://aoe4world.com/). For build or
   * Add or remove build orders with **Add/Remove build order** (write the content on the left panel, and the title on the top of the right panel).
     * Write anything for the *Simple TXT format*.
     * For the *Illustrated format*, you need to have a JSON format compatible with the [RTS_Overlay](https://github.com/CraftySalamander/RTS_Overlay) from CraftySalamander (see examples [here](https://github.com/CraftySalamander/RTS_Overlay/tree/master/build_orders/aoe4)).
-    * Many build orders can be downloaded from https://age4builder.com (currently only for *Simple TXT format*, but soon available for both formats).
+    * Many build orders can be downloaded from https://age4builder.com.
+      * To get the *Simple TXT format*, click on **Simple TXT Build Order to clipboard** on the top of any open build order (`M` icon).
+      * To get the *Illustrated format*, click on **Illustrated Build Order to clipboard** on the top of any open build order (**salamander** icon).
   * Change their order using **Move build order up/down**.
   * Set up hotkeys (with **Hotkey for/to...**) for showing/hiding overlay, cycling between build orders and selecting the previous/next step of a build order (only available for the *Illustrated format*).
     * Use the corresponding hotkeys to show/hide/cycle build orders and steps.

--- a/src/overlay/build_order_tools.py
+++ b/src/overlay/build_order_tools.py
@@ -420,7 +420,8 @@ class MultiQLabelDisplay:
             elif text_alignment == 'right':
                 label.setAlignment(Qt.AlignRight)
 
-    def add_row_from_picture_line(self, parent, line: str, labels_settings: list = None):
+    def add_row_from_picture_line(self, parent, line: str, labels_settings: list = None,
+                                  use_pictures: bool = True):
         """Add a row of labels based on a line mixing text and images.
 
         Parameters
@@ -429,11 +430,13 @@ class MultiQLabelDisplay:
         line               string text line with images between @ markers (e.g. 'text @image@ text')
         labels_settings    settings for the QLabel elements, must be the same size as the line after splitting,
                            see 'split_multi_label_line' function (None for default settings).
+        use_pictures       True to use pictures (if available), False to display line as it is.
         """
         if len(line) == 0:
             return
 
-        if (self.game_pictures_folder is None) and (self.common_pictures_folder is None):  # no picture
+        # no picture
+        if (not use_pictures) or ((self.game_pictures_folder is None) and (self.common_pictures_folder is None)):
             label = QLabel('', parent)
             label.setFont(QFont(self.font_police, self.font_size))
             label.setText(line)

--- a/src/overlay/tab_build_orders.py
+++ b/src/overlay/tab_build_orders.py
@@ -138,11 +138,12 @@ class BuildOrderOverlay(QtWidgets.QMainWindow):
                 str(target_gold) if (target_gold >= 0) else ' ')
             resources_line += spacing + '@' + settings.image_stone + '@ ' + (
                 str(target_stone) if (target_stone >= 0) else ' ')
-            resources_line += spacing + '@' + settings.image_villager + '@ ' + (
-                str(target_villager) if (target_villager >= 0) else ' ')
-            resources_line += spacing + '@' + settings.image_population + '@ ' + (
-                str(target_population) if (target_population >= 0) else ' ')
-            resources_line += spacing + '@' + get_age_image(target_age)
+            if target_villager >= 0:
+                resources_line += spacing + '@' + settings.image_villager + '@ ' + str(target_villager)
+            if target_population >= 0:
+                resources_line += spacing + '@' + settings.image_population + '@ ' + str(target_population)
+            if 1 <= target_age <= 4:
+                resources_line += spacing + '@' + get_age_image(target_age)
             if 'time' in data:  # add time if indicated
                 resources_line += '@' + spacing + '@' + settings.image_time + '@' + data['time']
 

--- a/src/overlay/tab_build_orders.py
+++ b/src/overlay/tab_build_orders.py
@@ -152,7 +152,7 @@ class BuildOrderOverlay(QtWidgets.QMainWindow):
             for note in notes:
                 self.build_order_notes.add_row_from_picture_line(parent=self, line=note)
         elif 'txt' in data:  # simple TXT file for build order:
-            self.build_order_notes.add_row_from_picture_line(parent=self, line=str(data['txt']))
+            self.build_order_notes.add_row_from_picture_line(parent=self, line=str(data['txt']), use_pictures=False)
         else:
             logger.info('Invalid data for build order.')
 


### PR DESCRIPTION
https://age4builder.com was updated and now correctly outputs the old (Simple TXT) and the new (Illustrated) build order formats.

These are small updates, corrections after testing age4builder and its integration in AoE4_Overlay.

After merge, you can check if everything seems fine for both formats when copying from age4builder. If it is the case, I think the code is ready for release 1.4.0.