### PR TITLE
check states for the build orders

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
-## [1.4.0] - 2022.07.25
+## [1.4.2] - in progress
+* Build orders can be unchecked, so that they do not appear when cycling between the build orders with the dedicated hotkey.
 
+## [1.4.0] - 2022.07.25
 * The order of the build orders can be adapted with 'Move build order up/down'.
 * Two format of build orders are available:
     * JSON format with images and resources distribution, adapted from the RTS Overlay of CraftySalamander.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ API calls are done through [AoE4World.com](https://aoe4world.com/). For build or
   * Change their order using **Move build order up/down**.
   * Set up hotkeys (with **Hotkey for/to...**) for showing/hiding overlay, cycling between build orders and selecting the previous/next step of a build order (only available for the *Illustrated format*).
     * Use the corresponding hotkeys to show/hide/cycle build orders and steps.
+    * You can uncheck a build order so that it does not appear when cycling between the build orders with the dedicated hotkey.
   * Change the overlay font size with **Overlay font size**.
   * Change the height of the build order images (only for the *Illustrated format*) with **Overlay images height**.
   * Change the position of the build order overlay with **Change BO overlay position**. Once fixed, the upper right corner will never move, but the size of the overlay will be automatically adapted to its content.

--- a/src/overlay/settings.py
+++ b/src/overlay/settings.py
@@ -50,12 +50,14 @@ class _Settings:
         # store build orders
         self.buildorders: Dict[str, str] = {
             "Instructions":
-            "Write your own build order.\n"
-            "You can also copy one from the https://age4builder.com website.\n\n"
-            "Two formats are accepted (both available on https://age4builder.com):\n"
-            "* Simple TXT format.\n"
-            "* JSON format compatible with CraftySalamander overlay."
+                "Write your own build order.\n"
+                "You can also copy one from the https://age4builder.com website\n"
+                "    (click on the salamander icon and paste it here).\n\n"
+                "Two formats are accepted (both available on https://age4builder.com):\n"
+                "* Simple TXT format.\n"
+                "* JSON format compatible with CraftySalamander overlay."
         }
+        self.unchecked_buildorders: list = []  # list of build orders which are not checked at launch
         # images
         self.image_wood: str = 'resource/resource_wood.png'  # wood resource
         self.image_food: str = 'resource/resource_food.png'  # food resource

--- a/src/overlay/tab_build_orders.py
+++ b/src/overlay/tab_build_orders.py
@@ -576,7 +576,9 @@ class BoTab(QtWidgets.QWidget):
 
     def add_build_order(self):
         """Add a new build order"""
-        self.bo_list.addItem(f"Build order {self.bo_list.count() + 1}")
+        item = QtWidgets.QListWidgetItem(f"Build order {self.bo_list.count() + 1}")
+        item.setCheckState(QtCore.Qt.Checked)
+        self.bo_list.addItem(item)
         self.bo_list.setCurrentRow(self.bo_list.count() - 1)
         self.save_current_bo()
         self.update_order()

--- a/src/overlay/tab_build_orders.py
+++ b/src/overlay/tab_build_orders.py
@@ -305,12 +305,9 @@ def hotkey_changed(new_hotkey: str, hotkey_str: str,
 class BoTab(QtWidgets.QWidget):
     """Tab used to configure the build order (BO) overlay"""
     show_hide_overlay = QtCore.pyqtSignal()  # show/hide the BO
-    cycle_build_order = QtCore.pyqtSignal(
-    )  # cycle between the different BO available
-    previous_step_build_order = QtCore.pyqtSignal(
-    )  # go to the previous step of the build order
-    next_step_build_order = QtCore.pyqtSignal(
-    )  # go to the next step of the build order
+    cycle_build_order = QtCore.pyqtSignal()  # cycle between the different BO available
+    previous_step_build_order = QtCore.pyqtSignal()  # go to the previous step of the build order
+    next_step_build_order = QtCore.pyqtSignal()  # go to the next step of the build order
 
     def __init__(self, parent):
         """Constructor
@@ -357,6 +354,7 @@ class BoTab(QtWidgets.QWidget):
 
     def closeEvent(self, _):
         """Function called when closing the widget."""
+        self.save_unchecked_state()
         self.overlay.close()
 
     def init_hotkeys(self):
@@ -405,9 +403,14 @@ class BoTab(QtWidgets.QWidget):
         # list of build orders
         vertical_layout.addWidget(self.bo_list)
         for name in settings.buildorders:
-            self.bo_list.addItem(name)
+            item = QtWidgets.QListWidgetItem(name)
+            item.setCheckState(QtCore.Qt.Unchecked if (name in settings.unchecked_buildorders) else QtCore.Qt.Checked)
+            self.bo_list.addItem(item)
         self.bo_list.currentItemChanged.connect(self.bo_selected)
-        self.bo_list.setCurrentRow(0)
+
+        self.bo_list.setCurrentRow(0)  # set first selected item
+        if self.bo_list.currentItem().checkState() == QtCore.Qt.Unchecked:
+            self.cycle_overlay()
 
         # add build order
         add_bo_button = QtWidgets.QPushButton("Add build order")
@@ -549,8 +552,8 @@ class BoTab(QtWidgets.QWidget):
         self.bo_list.currentItem().setText(text)
 
         # remove the old build order
-        rows = self.bo_list.count()
-        bo_names = {self.bo_list.item(i).text() for i in range(rows)}
+        rows_count = self.bo_list.count()
+        bo_names = {self.bo_list.item(i).text() for i in range(rows_count)}
         for name in settings.buildorders:
             if name not in bo_names:
                 del settings.buildorders[name]
@@ -564,8 +567,8 @@ class BoTab(QtWidgets.QWidget):
         old_build_orders = settings.buildorders.copy()
         settings.buildorders.clear()
 
-        rows = self.bo_list.count()
-        for i in range(rows):
+        rows_count = self.bo_list.count()
+        for i in range(rows_count):
             name = self.bo_list.item(i).text()
             if (name in old_build_orders) and (name
                                                not in settings.buildorders):
@@ -706,7 +709,7 @@ class BoTab(QtWidgets.QWidget):
         self.build_order_step -= 1
         self.limit_build_order_step()
         if (init_build_order_step !=
-                self.build_order_step) and (self.build_order_step >= 0):
+            self.build_order_step) and (self.build_order_step >= 0):
             self.update_overlay()
 
     def select_next_build_order_step(self):
@@ -715,15 +718,29 @@ class BoTab(QtWidgets.QWidget):
         self.build_order_step += 1
         self.limit_build_order_step()
         if (init_build_order_step !=
-                self.build_order_step) and (self.build_order_step >= 0):
+            self.build_order_step) and (self.build_order_step >= 0):
             self.update_overlay()
 
     def cycle_overlay(self):
-        """ Cycles through build orders and sends data to the overlay"""
-        self.bo_list.setCurrentRow(
-            (self.bo_list.currentRow() + 1) % self.bo_list.count())
-        self.build_order_step = -1
-        self.update_overlay()
+        """ Cycle through build orders and send data to the overlay"""
+        rows_count = self.bo_list.count()
+        init_id = self.bo_list.currentRow()  # initially selected build order ID
+
+        current_id = init_id + 1  # current build order ID to check
+        if current_id >= rows_count:
+            current_id = 0
+
+        while current_id != init_id:  # stop if back to the initial ID
+
+            if self.bo_list.item(current_id).checkState() == QtCore.Qt.Checked:  # valid build order found
+                self.bo_list.setCurrentRow(current_id)
+                self.build_order_step = -1
+                self.update_overlay()
+                return
+
+            current_id += 1  # go to next build order ID
+            if current_id >= rows_count:
+                current_id = 0
 
     def update_overlay(self):
         """Send new data to the overlay"""
@@ -750,3 +767,11 @@ class BoTab(QtWidgets.QWidget):
                 self.build_order_step_count = -1
                 self.overlay.update_build_order_display(title=bo_name,
                                                         data={'txt': bo_text})
+
+    def save_unchecked_state(self):
+        """Save the state of the unchecked build orders"""
+        settings.unchecked_buildorders.clear()
+        rows_count = self.bo_list.count()
+        for row_id in range(rows_count):
+            if self.bo_list.item(row_id).checkState() == QtCore.Qt.Unchecked:
+                settings.unchecked_buildorders.append(self.bo_list.item(row_id).text())


### PR DESCRIPTION
Implementing solution for Issue #12 : Add a check mark to hide a build order from rotation via the keyboard shortcut.
