### PR TITLE
Feature: Option to show MMR (ELO) instead of Ranked Points

### DIFF
--- a/src/overlay/helper_func.py
+++ b/src/overlay/helper_func.py
@@ -148,15 +148,22 @@ def process_game(game_data: Dict[str, Any]) -> Dict[str, Any]:
 
         mode_data = player.get('modes', {}).get(lookup_mode, {})
         mode_str = lookup_mode.split('_')[0].upper()
+
+        rating_val = mode_data.get('rating', 0)
+        if settings.show_mmr_instead_of_rank:
+            # Try to get MMR, fall back to rating if not available (e.g. for QM sometimes)
+            rating_val = mode_data.get('mmr', rating_val)
+
         data = {
             'civ': current_civ.replace("_", " ").title(),
             'name': name,
             'team': zeroed(player['team'] + 1),
             'country': player['country'],
-            'rating': str(mode_data.get('rating', 0)),
+            'rating': str(rating_val),
             'rank': f"{mode_str}#{mode_data.get('rank',0)}",
             'wins': str(mode_data.get('wins_count', 0)),
             'losses': str(mode_data.get('losses_count', 0)),
+
             'winrate': f"{mode_data.get('win_rate', 0)}%",
             'civ_games': civ_games,
             'civ_winrate': civ_winrate,

--- a/src/overlay/settings.py
+++ b/src/overlay/settings.py
@@ -24,6 +24,7 @@ class _Settings:
         self.overlay_geometry: Optional[List[int]] = None
         self.font_size: int = 12
         self.max_games_history: int = 100
+        self.show_mmr_instead_of_rank: bool = False
         self.civ_stats_color: str = "#BC8AEA"
         self.open_overlay_on_new_game = True
         self.show_graph = {"1": True, "2": True, "3": True, "4": True}

--- a/src/overlay/tab_settings.py
+++ b/src/overlay/tab_settings.py
@@ -109,6 +109,13 @@ class SettingsTab(QtWidgets.QWidget):
             self.font_size_changed)
         overlay_layout.addWidget(self.font_size_combo, 1, 1)
 
+        # Show MMR instead of rank
+        self.show_mmr_checkbox = QtWidgets.QCheckBox("Show MMR instead of Rank Points")
+        self.show_mmr_checkbox.setToolTip("If checked, shows internal MMR (ELO) instead of visible Ranked Points for ranked games.")
+        self.show_mmr_checkbox.setChecked(settings.show_mmr_instead_of_rank)
+        self.show_mmr_checkbox.stateChanged.connect(self.show_mmr_changed)
+        overlay_layout.addWidget(self.show_mmr_checkbox, 2, 0, 1, 2)
+
         # Position change button
         self.btn_change_position = QtWidgets.QPushButton(
             "Change/fix overlay position")
@@ -117,7 +124,7 @@ class SettingsTab(QtWidgets.QWidget):
         )
         self.btn_change_position.clicked.connect(
             self.overlay_widget.change_state)
-        overlay_layout.addWidget(self.btn_change_position, 2, 0, 1, 2)
+        overlay_layout.addWidget(self.btn_change_position, 3, 0, 1, 2)
 
         ### Messages
         self.msg = QtWidgets.QLabel()
@@ -228,6 +235,9 @@ class SettingsTab(QtWidgets.QWidget):
         font_size = self.font_size_combo.currentIndex() + 1
         settings.font_size = font_size
         self.overlay_widget.update_style(font_size)
+
+    def show_mmr_changed(self, state):
+        settings.show_mmr_instead_of_rank = bool(state)
 
     def hotkey_changed(self, new_hotkey: str):
         """ Checks whether the hotkey is actually new and valid.


### PR DESCRIPTION
Adds a setting to the Settings tab to toggle between displaying visible Ranked Points and internal MMR (ELO) for ranked games.