### PR TITLE
Fix proxy support for system proxies

### DIFF
--- a/src/overlay/api_checking.py
+++ b/src/overlay/api_checking.py
@@ -1,5 +1,6 @@
 import json
 import time
+import urllib.request
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
@@ -9,7 +10,19 @@ from overlay.logging_func import get_logger
 from overlay.settings import settings
 
 logger = get_logger(__name__)
-session = requests.session()
+
+
+def _create_session() -> requests.Session:
+    """Creates a requests session using system proxy settings (e.g. Clash/Flclash)."""
+    s = requests.Session()
+    proxies = urllib.request.getproxies()
+    if proxies:
+        s.proxies.update(proxies)
+        logger.info(f"Using system proxies: {proxies}")
+    return s
+
+
+session = _create_session()
 
 
 def find_player(text: str) -> bool:

--- a/src/overlay/helper_func.py
+++ b/src/overlay/helper_func.py
@@ -4,6 +4,7 @@ import pathlib
 import sys
 import time
 import traceback
+import urllib.request
 from typing import Any, Dict, Optional, Union
 
 import requests
@@ -50,7 +51,7 @@ def version_check(version: str) -> str:
     """ Checks version. Returns either link for the new version or an empty string. """
     try:
         url = "https://raw.githubusercontent.com/FluffyMaguro/AoE4_Overlay/main/version.json"
-        data = json.loads(requests.get(url).text)
+        data = json.loads(requests.get(url, proxies=urllib.request.getproxies()).text)
         if version_to_int(version) < version_to_int(data['version']):
             return data['link']
     except Exception:


### PR DESCRIPTION
## Summary

- Fix requests session not using system proxy settings (e.g. Clash/Flclash on Windows)
- Explicitly read system proxies via `urllib.request.getproxies()` and apply them to the `requests.Session` in `api_checking.py`
- Apply the same fix to the version check HTTP call in `helper_func.py`

## Description

On Windows, tools like Clash/Flclash set a system-level HTTP/HTTPS proxy, but the `requests` library's automatic proxy detection can be unreliable in this context. This fix explicitly reads the system proxy configuration and applies it to all outgoing HTTP requests made to the aoe4world API and GitHub version check endpoint.
